### PR TITLE
Updated Readme and recti simple bug when `libpcap` is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,27 @@ requires a working interface to the host for ssh access:
 The above sets up two interfaces, one for the primary connection that uses
 the UDP NAT interface of tunsocks, and a second interface for ssh access.
 
+Compile
+-------
+
+Compiling tunsocks is fairly easy one. You need to clone and initialize its git modules using following commands
+
+    git clone https://github.com/russdill/tunsocks
+    git submodule init
+    git submodule update
+
+Then you need to make sure all prerequisites are installed
+
+- `libevent`
+- `autotools`
+- `make`
+
+For compiling the code you just need to run:
+
+    ./autogen.sh
+    ./configure
+    make
+
 Credits
 -------
 

--- a/src/main.c
+++ b/src/main.c
@@ -221,7 +221,9 @@ int main(int argc, char *argv[])
 	fd_in = 0;
 	fd_out = 1;
 	mtu = 0;
+#ifdef USE_PCAP
 	pcap_entries = NULL;
+#endif
 	non_local = 0;
 	nat_port_raw = 0;
 	nat_port_len = 0;


### PR DESCRIPTION
- Converted Readme to markdown
- compiling is added to Readme
- a bug when `libpcap` is disbaled rectified